### PR TITLE
add Arr::wrapAssoc method

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -951,4 +951,15 @@ class Arr
 
         return is_array($value) ? $value : [$value];
     }
+
+    /**
+     * If the given value is an associative array, wrap it in an array.
+     *
+     * @param  array  $value
+     * @return array
+     */
+    public static function wrapAssoc(array $value)
+    {
+        return static::isAssoc($value) ? [$value] : $value;
+    }
 }

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -1358,6 +1358,21 @@ class SupportArrTest extends TestCase
         $this->assertSame($obj, Arr::wrap($obj)[0]);
     }
 
+    public function testWrapAssoc()
+    {
+        $sequential = ['a', 'b', 'c'];
+        $sequentialArrays = [['key' => 1], ['key' => 2], ['key' => 3]];
+        $associative = ['key' => 1, 'value' => 'foo'];
+        $combination = ['a', 'b', 'c' => ['abc']];
+        $empty = [];
+
+        $this->assertEquals($sequential, Arr::wrapAssoc($sequential));
+        $this->assertEquals($sequentialArrays, Arr::wrapAssoc($sequentialArrays));
+        $this->assertEquals([$associative], Arr::wrapAssoc($associative));
+        $this->assertEquals([$combination], Arr::wrapAssoc($combination));
+        $this->assertEquals([], Arr::wrapAssoc($empty));
+    }
+
     public function testSortByMany()
     {
         $unsorted = [


### PR DESCRIPTION
Testing before opening merge into Laravel

---

This adds `Arr::wrapAssoc()` which wraps associative arrays in an array, leaving natural array unchanged.

**Example Usage:**

```php
Arr::wrapAssoc(['key' => 'foo']);      // Returns: [['key' => 'foo']]
Arr::wrapAssoc([['key' => 'foo']]);    // Returns: [['key' => 'foo']] (unchanged)
```

**Motivation:**

In API responses, especially from SOAP/XML services, single items often appear as associative arrays, while lists are multi-dimensional arrays. The `wrapAssoc` method provides a consistent format, reducing boilerplate and improving readability by avoiding repeated checks:

```diff
- foreach (Arr::isAssoc($data['Item']) ? [$data['Item']] : $data['Item'] as $item) {
+ foreach (Arr::wrapAssoc($data['Item']) as $item) {
```