### PR TITLE
add generics to Arr::wrap to better understand return type

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -941,7 +941,8 @@ class Arr
      * If the given value is not an array and not null, wrap it in one.
      *
      * @template T
-     * @param T|array|null $value
+     *
+     * @param  T|array|null  $value
      * @return ($value is array ? T : ($value is null ? array<never, never> : array{0: T}))
      */
     public static function wrap($value)

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -940,8 +940,9 @@ class Arr
     /**
      * If the given value is not an array and not null, wrap it in one.
      *
-     * @param  mixed  $value
-     * @return array
+     * @template T
+     * @param T|array|null $value
+     * @return ($value is array ? T : ($value is null ? array<never, never> : array{0: T}))
      */
     public static function wrap($value)
     {


### PR DESCRIPTION
Testing before opening merge into Laravel

---

This MR adds the following generics to the `Illuminate\Support\Arr::wrap()` method:

```php
     * @template T
     * @param T|array $value
     * @return ($value is array ? T : array{0: T})
```

These annotations allow IDEs and tools like PHPStan or Psalm to more accurately infer the return type based on the input.

**Example Usage**

```php
Arr::wrap('apple'); 
// Returns ['apple']
// Type: array{0: string}

Arr::wrap(['apple', 'banana']);
// Returns: ['apple', 'banana']
// Type: array<string>

Arr::wrap(null);
// Returns: []
// Type: array<never>
```
